### PR TITLE
fix: 更换trace工具的内部计时实现

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanhan9449/react-hooks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "常用的react hooks实现",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/src/utils/trace.ts
+++ b/src/utils/trace.ts
@@ -17,19 +17,19 @@ export function geneLabel(name: string): string {
 export function trace<T extends AnyFn>(fn: T, name?: string): T {
     const label = geneLabel(name || fn.name)
     return function(...args: Parameters<T>) {
-        console.time(label)
+        const start = performance.now()
         const result = fn(...args) as ReturnType<T>
         // @ts-ignore if result is primitive return false, no error
         if (result instanceof Promise) {
             return result.then(result => {
-                console.timeEnd(label)
+                console.log(label, performance.now() - start)
                 return result
             }).catch(err => {
-                console.timeEnd(label)
+                console.log(label, performance.now() - start)
                 return err
             })
         } else {
-            console.timeEnd(label)
+            console.log(label, performance.now() - start)
             return result
         }
     }  as T


### PR DESCRIPTION
1. console.time不稳定，不同浏览器上的实现不一致，替换实现